### PR TITLE
feat: add service selection and theme palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,8 +37,9 @@
 
         /* Floating social icon animation */
         .social-icon {
-            @apply w-12 h-12 rounded-full flex items-center justify-center text-white shadow-lg transition-transform duration-300;
-            background-color: var(--brand-accent);
+            @apply w-12 h-12 rounded-full flex items-center justify-center shadow-lg transition-transform duration-300;
+            color: var(--brand-accent);
+            background-color: transparent;
             animation: float 3s ease-in-out infinite;
         }
         .social-icon:hover {
@@ -52,7 +53,7 @@
 
         /* New Service Card Styles */
         .service-card-selectable {
-            @apply bg-white p-4 rounded-xl border-2 border-gray-300 flex items-center justify-between transition-all duration-300 cursor-pointer relative;
+            @apply bg-white p-4 rounded-xl border-2 border-black flex items-center justify-between transition-all duration-300 cursor-pointer relative;
         }
         .service-card-selectable.selected {
             border-color: var(--brand-accent);
@@ -194,13 +195,15 @@
     }
     </script>
 
-    <div id="floating-social-bar" class="flex-col space-y-2 fixed left-5 top-1/2 -translate-y-1/2 z-40 bg-white/80 backdrop-blur-md shadow-lg rounded-full p-2 hidden md:flex">
+    <div id="floating-social-bar" class="flex-col space-y-2 fixed left-5 top-1/2 -translate-y-1/2 z-40 backdrop-blur-md shadow-lg rounded-full p-2 hidden md:flex">
         <!-- Social icons will be injected here -->
     </div>
 
     <div id="floating-action-buttons" class="fixed bottom-6 right-6 z-40 bg-white/80 backdrop-blur-md rounded-full flex flex-col items-center p-2 space-y-1 shadow-lg">
         <!-- Action buttons will be injected here -->
     </div>
+
+    <div id="color-palette" class="fixed bottom-6 right-24 z-40 bg-white/80 backdrop-blur-md rounded-full flex items-center p-2 space-x-2 shadow-lg"></div>
 
     <header class="bg-white/80 backdrop-blur-md fixed top-0 left-0 right-0 z-50 border-b border-gray-200">
         <div class="container mx-auto px-6 py-4 flex justify-between items-center">
@@ -365,6 +368,31 @@
                 .service-card-icon-new { background-color: var(--brand-light); color: var(--brand-accent); }
                 .service-filter-btn.active { background-color: var(--brand-charcoal); color: white; border-color: var(--brand-charcoal); }
             `;
+
+            function applyTheme(theme) {
+                document.documentElement.style.setProperty('--brand-charcoal', theme.charcoal);
+                document.documentElement.style.setProperty('--brand-accent', theme.accent);
+                document.documentElement.style.setProperty('--brand-light', theme.light);
+            }
+
+            applyTheme(data.theme);
+
+            const paletteContainer = document.getElementById('color-palette');
+            if (paletteContainer) {
+                const palettes = [
+                    data.theme,
+                    { charcoal: '#1E293B', accent: '#3B82F6', light: '#DBEAFE' },
+                    { charcoal: '#1F2937', accent: '#10B981', light: '#D1FAE5' },
+                    { charcoal: '#312E81', accent: '#8B5CF6', light: '#EDE9FE' }
+                ];
+                palettes.forEach(palette => {
+                    const btn = document.createElement('button');
+                    btn.className = 'w-6 h-6 rounded-full border border-gray-300';
+                    btn.style.backgroundColor = palette.accent;
+                    btn.addEventListener('click', () => applyTheme(palette));
+                    paletteContainer.appendChild(btn);
+                });
+            }
 
             const floatingActionButtons = document.getElementById('floating-action-buttons');
             floatingActionButtons.innerHTML = `


### PR DESCRIPTION
## Summary
- show selectable service cards with black borders and green checkmarks
- remove background from social bar and tweak icon styling
- add theme color palette for quick site recoloring

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f6450314c832e8a49dd9fe46e131b