### PR TITLE
Enhance profile layout with colors, media, and navigation fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,12 +137,19 @@
         { "name": "Sophia Garcia", "title": "Nail & Skin Specialist", "image": "https://placehold.co/400x400/FDFBF8/36322F?text=Sophia" }
       ],
       "reels": [
-        "https://placehold.co/1280x720/C08261/FFFFFF?text=Main+Video",
-        "https://placehold.co/1280x720/F5EFE6/36322F?text=Reel+2",
-        "https://placehold.co/1280x720/36322F/FFFFFF?text=Reel+3"
+        "https://samplelib.com/lib/preview/mp4/sample-5s.mp4",
+        "https://samplelib.com/lib/preview/mp4/sample-10s.mp4",
+        "https://samplelib.com/lib/preview/mp4/sample-15s.mp4"
       ],
       "gallery": [
-        "https://placehold.co/800x1000/F5EFE6/36322F?text=Style", "https://placehold.co/800x800/F5EFE6/36322F?text=Style", "https://placehold.co/800x1200/F5EFE6/36322F?text=Style", "https://placehold.co/800x900/F5EFE6/36322F?text=Style", "https://placehold.co/800x1100/F5EFE6/36322F?text=Style", "https://placehold.co/800x800/F5EFE6/36322F?text=Style", "https://placehold.co/800x1000/F5EFE6/36322F?text=Style", "https://placehold.co/800x900/F5EFE6/36322F?text=Style"
+        "https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1503342452485-86b7f54527dd?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1501870190088-42259e120fd9?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1500835556837-99ac94a94552?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=800&q=80"
       ]
     }
     </script>
@@ -185,12 +192,19 @@
         { "name": "Mia Rodriguez", "title": "Nail & Lash Artist", "image": "https://placehold.co/400x400/F3E8FF/43384a?text=Mia" }
       ],
       "reels": [
-        "https://placehold.co/1280x720/8B5CF6/FFFFFF?text=Main+Video",
-        "https://placehold.co/1280x720/F3E8FF/43384a?text=Reel+2",
-        "https://placehold.co/1280x720/43384a/FFFFFF?text=Reel+3"
+        "https://samplelib.com/lib/preview/mp4/sample-5s.mp4",
+        "https://samplelib.com/lib/preview/mp4/sample-10s.mp4",
+        "https://samplelib.com/lib/preview/mp4/sample-15s.mp4"
       ],
       "gallery": [
-        "https://placehold.co/800x1000/F3E8FF/43384a?text=Style", "https://placehold.co/800x800/F3E8FF/43384a?text=Style", "https://placehold.co/800x1200/F3E8FF/43384a?text=Style", "https://placehold.co/800x900/F3E8FF/43384a?text=Style", "https://placehold.co/800x1100/F3E8FF/43384a?text=Style", "https://placehold.co/800x800/F3E8FF/43384a?text=Style", "https://placehold.co/800x1000/F3E8FF/43384a?text=Style", "https://placehold.co/800x900/F3E8FF/43384a?text=Style"
+        "https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1503342452485-86b7f54527dd?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1501870190088-42259e120fd9?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1500835556837-99ac94a94552?auto=format&fit=crop&w=800&q=80",
+        "https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=800&q=80"
       ]
     }
     </script>
@@ -203,8 +217,6 @@
         <!-- Action buttons will be injected here -->
     </div>
 
-    <div id="color-palette" class="fixed bottom-6 right-24 z-40 bg-white/80 backdrop-blur-md rounded-full flex items-center p-2 space-x-2 shadow-lg"></div>
-
     <header class="bg-white/80 backdrop-blur-md fixed top-0 left-0 right-0 z-50 border-b border-gray-200">
         <div class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 id="header-brand-name" class="text-3xl font-bold text-brand-charcoal"></h1>
@@ -213,12 +225,15 @@
                 <a href="#reviews" class="hover:text-brand-accent transition-colors">Reviews</a>
                 <a href="#stylists" class="hover:text-brand-accent transition-colors">Our Team</a>
             </nav>
-            <a href="#contact" class="hidden md:inline-block btn btn-primary btn-glow">Book Now</a>
-             <button id="mobile-menu-button" class="md:hidden">
-                <i class="fas fa-bars text-2xl"></i>
-            </button>
+            <div class="flex items-center space-x-4">
+                <a href="#contact" class="hidden md:inline-block btn btn-primary btn-glow">Book Now</a>
+                <div id="color-palette" class="flex items-center space-x-2 bg-white/80 backdrop-blur-md rounded-full p-2 shadow-lg"></div>
+                <button id="mobile-menu-button" class="md:hidden">
+                    <i class="fas fa-bars text-2xl"></i>
+                </button>
+            </div>
         </div>
-         <div id="mobile-menu" class="hidden md:hidden px-6 pt-2 pb-4 bg-white border-t">
+        <div id="mobile-menu" class="hidden md:hidden px-6 pt-2 pb-4 bg-white border-t">
             <a href="#services" class="block py-2 hover:text-brand-accent">Services</a>
             <a href="#reviews" class="block py-2 hover:text-brand-accent">Reviews</a>
             <a href="#stylists" class="block py-2 hover:text-brand-accent">Our Team</a>
@@ -366,6 +381,16 @@
                 .social-icon:hover { color: var(--brand-accent); }
                 .page-action-btn:hover { color: var(--brand-accent); }
                 .service-card-icon-new { background-color: var(--brand-light); color: var(--brand-accent); }
+                .service-filter-btn {
+                    border: 2px solid var(--brand-accent);
+                    color: var(--brand-charcoal);
+                    background-color: white;
+                    border-radius: 9999px;
+                    padding: 0.5rem 1rem;
+                    font-weight: 600;
+                    white-space: nowrap;
+                    transition: background-color 0.3s, color 0.3s;
+                }
                 .service-filter-btn.active { background-color: var(--brand-charcoal); color: white; border-color: var(--brand-charcoal); }
             `;
 
@@ -383,7 +408,13 @@
                     data.theme,
                     { charcoal: '#1E293B', accent: '#3B82F6', light: '#DBEAFE' },
                     { charcoal: '#1F2937', accent: '#10B981', light: '#D1FAE5' },
-                    { charcoal: '#312E81', accent: '#8B5CF6', light: '#EDE9FE' }
+                    { charcoal: '#312E81', accent: '#8B5CF6', light: '#EDE9FE' },
+                    { charcoal: '#292524', accent: '#F97316', light: '#FFEDD5' },
+                    { charcoal: '#1C1917', accent: '#EC4899', light: '#FCE7F3' },
+                    { charcoal: '#0F172A', accent: '#14B8A6', light: '#CCFBF1' },
+                    { charcoal: '#111827', accent: '#6366F1', light: '#E0E7FF' },
+                    { charcoal: '#171717', accent: '#F59E0B', light: '#FEF3C7' },
+                    { charcoal: '#0a0f0d', accent: '#94a3b8', light: '#f1f5f9' }
                 ];
                 palettes.forEach(palette => {
                     const btn = document.createElement('button');
@@ -485,8 +516,7 @@
             reelsContainer.innerHTML = (data.reels || []).map(reelUrl => `
                 <div class="snap-center flex-shrink-0 w-full md:w-1/2 lg:w-1/3">
                     <div class="relative aspect-video rounded-lg shadow-lg overflow-hidden">
-                        <img src="${reelUrl}" onerror="this.onerror=null;this.src='https://placehold.co/1280x720/cccccc/ffffff?text=Video';" class="w-full h-full object-cover" alt="Reel thumbnail">
-                        <div class="absolute inset-0 bg-black/30 flex items-center justify-center"> <button class="text-white text-6xl opacity-80 hover:opacity-100 transition"><i class="fas fa-play-circle"></i></button> </div>
+                        <video src="${reelUrl}" controls muted loop class="w-full h-full object-cover"></video>
                     </div>
                 </div>
             `).join('');
@@ -604,6 +634,30 @@
                     item.addEventListener('click', () => {
                         item.classList.toggle('selected');
                     });
+                });
+            }
+
+            const reviewsContainerScroll = document.getElementById('reviews-container');
+            const reviewsScrollLeft = document.getElementById('reviews-scroll-left');
+            const reviewsScrollRight = document.getElementById('reviews-scroll-right');
+            if (reviewsContainerScroll && reviewsScrollLeft && reviewsScrollRight) {
+                reviewsScrollLeft.addEventListener('click', () => {
+                    reviewsContainerScroll.scrollBy({ left: -reviewsContainerScroll.clientWidth, behavior: 'smooth' });
+                });
+                reviewsScrollRight.addEventListener('click', () => {
+                    reviewsContainerScroll.scrollBy({ left: reviewsContainerScroll.clientWidth, behavior: 'smooth' });
+                });
+            }
+
+            const reelsContainerScroll = document.getElementById('reels-container');
+            const reelsScrollLeft = document.getElementById('reels-scroll-left');
+            const reelsScrollRight = document.getElementById('reels-scroll-right');
+            if (reelsContainerScroll && reelsScrollLeft && reelsScrollRight) {
+                reelsScrollLeft.addEventListener('click', () => {
+                    reelsContainerScroll.scrollBy({ left: -reelsContainerScroll.clientWidth, behavior: 'smooth' });
+                });
+                reelsScrollRight.addEventListener('click', () => {
+                    reelsContainerScroll.scrollBy({ left: reelsContainerScroll.clientWidth, behavior: 'smooth' });
                 });
             }
 


### PR DESCRIPTION
## Summary
- Move theme color palette into header and expand to ten options
- Style service category filters as cards
- Replace placeholder media with sample photos and videos
- Enable arrow scrolling for reviews and reels sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f67cbabb4832eb0017d6a8d4e7f2a