### PR TITLE
Add interactive animations and micro-interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         }
         
         .btn { @apply font-semibold py-3 px-8 rounded-md transition-all duration-300 ease-in-out; }
+        .btn:active, button:active, .service-filter-btn:active, .page-action-btn:active { @apply scale-95; }
         @keyframes glow {
             0%, 100% { box-shadow: 0 0 0 rgba(192,130,97,0.0); }
             50% { box-shadow: 0 0 20px rgba(192,130,97,0.6); }
@@ -56,6 +57,7 @@
             @apply bg-white p-4 rounded-lg border-2 overflow-hidden flex items-center justify-between transition-all duration-300 cursor-pointer relative shadow-md;
             border-color: var(--brand-accent);
         }
+        .service-card-selectable:hover { @apply -translate-y-1 shadow-xl; }
         .service-card-selectable.selected {
             border-color: var(--brand-accent);
             background-color: var(--brand-light);
@@ -94,9 +96,36 @@
         .gallery-item { break-inside: avoid; margin-bottom: 1rem; }
         .gallery-item img { transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out; border: 4px solid white; box-shadow: 0 4px 6px rgba(0,0,0,0.1); }
         .gallery-item:hover img { transform: scale(1.03); box-shadow: 0 10px 20px rgba(0,0,0,0.1); }
+
+        .stylist-card img { @apply transition-transform duration-300; }
+        .stylist-card:hover img { @apply scale-105; }
+        .stylist-card h4 { @apply transition-colors duration-300; }
+        .stylist-card:hover h4 { color: var(--brand-accent); }
+
+        .media-item { @apply relative overflow-hidden; }
+        .media-overlay { @apply absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center opacity-0 transition-opacity duration-300; }
+        .media-item:hover .media-overlay { @apply opacity-100; }
+
+        .reveal-left, .reveal-right { opacity: 0; transition: opacity 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94), transform 0.8s cubic-bezier(0.25, 0.46, 0.45, 0.94); }
+        .reveal-left { transform: translateX(-30px); }
+        .reveal-right { transform: translateX(30px); }
+        .reveal-left.visible, .reveal-right.visible { opacity: 1; transform: translateX(0); }
+
+        @keyframes fadeIn { from { opacity: 0; transform: scale(0.95); } to { opacity: 1; transform: scale(1); } }
+        .fade-in { animation: fadeIn 0.5s ease forwards; }
+
+        .blur-up { filter: blur(20px); transition: filter 0.5s ease; }
+        .blur-up.loaded { filter: blur(0); }
+
+        #preloader { @apply fixed inset-0 flex items-center justify-center bg-white z-50 transition-opacity duration-500; }
+        #preloader.fade-out { @apply opacity-0; }
+        #preloader-logo { @apply w-24 h-24; animation: preloaderPulse 1.5s ease-in-out infinite; }
+        @keyframes preloaderPulse { 0%,100% { opacity:0.3; } 50% { opacity:1; } }
     </style>
 </head>
 <body class="text-brand-charcoal">
+
+    <div id="preloader"><img id="preloader-logo" alt="Loading"></div>
 
     <!-- JSON Data embedded directly in the HTML -->
     <script id="shai-data" type="application/json">
@@ -271,7 +300,7 @@
             </div>
         </section>
 
-        <section id="stats" class="py-7 bg-brand-light">
+        <section id="stats" class="py-6 bg-brand-light">
             <div class="container mx-auto px-6">
                 <div id="stats-grid" class="grid grid-cols-1 md:grid-cols-4 gap-8"></div>
             </div>
@@ -379,6 +408,11 @@
             document.getElementById('footer-business-name').textContent = data.businessName;
             document.getElementById('company-logo').src = data.logo;
             document.getElementById('company-logo').alt = `${data.businessName} logo`;
+            const preloaderLogo = document.getElementById('preloader-logo');
+            if(preloaderLogo){
+                preloaderLogo.src = data.logo;
+                preloaderLogo.alt = `${data.businessName} loading`;
+            }
             document.getElementById('company-address').textContent = data.contact.location;
             document.getElementById('company-phone').textContent = data.contact.phone;
             document.getElementById('company-hours').textContent = data.contact.hours;
@@ -423,6 +457,16 @@
 
             applyTheme(data.theme);
 
+            function hexToRgb(hex) {
+                const h = hex.replace('#','');
+                const bigint = parseInt(h, 16);
+                const r = (bigint >> 16) & 255;
+                const g = (bigint >> 8) & 255;
+                const b = bigint & 255;
+                return `${r},${g},${b}`;
+            }
+            const accentRGB = hexToRgb(data.theme.accent);
+
             const paletteContainer = document.getElementById('color-palette');
             if (paletteContainer) {
                 const palettes = [
@@ -463,7 +507,7 @@
             
             const heroContainer = document.getElementById('hero-container');
             heroContainer.innerHTML = data.heroSlides.map(slide => `
-                <div class="hero-slide w-full h-full flex-shrink-0" style="background-image: linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), url('${slide.bgImage}');">
+                <div class="hero-slide w-full h-full flex-shrink-0" style="background-image: linear-gradient(rgba(${accentRGB},0.4), rgba(${accentRGB},0.4)), url('${slide.bgImage}');">
                     <div class="w-full h-full flex flex-col items-center justify-center text-center text-white p-6">
                         <div class="reveal">
                             <h2 class="text-4xl md:text-6xl font-bold leading-tight mb-4">${slide.title}</h2>
@@ -494,8 +538,8 @@
             `).join('');
 
             const serviceGrid = document.getElementById('service-grid');
-            serviceGrid.innerHTML = data.services.map(service => `
-                <div class="service-item service-card-selectable" data-category="${service.category}">
+            serviceGrid.innerHTML = data.services.map((service, index) => `
+                <div class="service-item service-card-selectable reveal" data-category="${service.category}" style="transition-delay: ${index * 100}ms;">
                     <div class="flex items-center space-x-4 flex-grow">
                         <div class="service-card-icon-new">${service.icon}</div>
                         <div> <h5 class="font-bold text-lg">${service.name}</h5> <p class="text-sm text-gray-500">${service.duration}</p> </div>
@@ -504,15 +548,17 @@
                     <div class="checkmark-icon"><i class="fas fa-check-circle"></i></div>
                 </div>
             `).join('');
-            
+
             const stylistsGrid = document.getElementById('stylists-grid');
             stylistsGrid.innerHTML = data.stylists.map((stylist, index) => `
-                 <div class="text-center reveal" style="transition-delay: ${index * 150}ms;">
-                    <div class="relative inline-block">
+                <div class="stylist-card text-center">
+                    <div class="relative inline-block reveal-left" style="transition-delay: ${index * 150}ms;">
                         <img src="${stylist.image}" onerror="this.onerror=null;this.src='https://placehold.co/400x400/cccccc/ffffff?text=Image';" alt="Stylist ${stylist.name}" class="w-full h-auto object-cover rounded-full aspect-square mx-auto mb-6 max-w-[250px] shadow-lg">
                     </div>
-                    <h4 class="text-2xl font-bold">${stylist.name}</h4>
-                    <p class="text-brand-accent font-semibold mb-2">${stylist.title}</p>
+                    <div class="reveal-right" style="transition-delay: ${index * 150 + 150}ms;">
+                        <h4 class="text-2xl font-bold">${stylist.name}</h4>
+                        <p class="text-brand-accent font-semibold mb-2">${stylist.title}</p>
+                    </div>
                 </div>
             `).join('');
 
@@ -537,16 +583,21 @@
             const reelsContainer = document.getElementById('reels-container');
             reelsContainer.innerHTML = (data.reels || []).map(reelUrl => `
                 <div class="snap-center flex-shrink-0 w-full md:w-1/2 lg:w-1/3">
-                    <div class="relative aspect-video rounded-lg shadow-lg overflow-hidden">
+                    <div class="media-item relative aspect-video rounded-lg shadow-lg overflow-hidden">
                         <video src="${reelUrl}" controls muted loop class="w-full h-full object-cover"></video>
+                        <div class="media-overlay pointer-events-none"><i class="fas fa-play text-white text-3xl"></i></div>
                     </div>
                 </div>
             `).join('');
 
             const galleryContainer = document.getElementById('gallery-container');
             galleryContainer.innerHTML = (data.gallery || []).map(imageUrl => `
-                <div class="gallery-item"> <img class="rounded-lg w-full" src="${imageUrl}" onerror="this.onerror=null;this.src='https://placehold.co/800x1000/cccccc/ffffff?text=Image';" alt="Gallery Image"> </div>
+                <div class="gallery-item media-item"> <img class="rounded-lg w-full blur-up" src="${imageUrl}" onerror="this.onerror=null;this.src='https://placehold.co/800x1000/cccccc/ffffff?text=Image';" alt="Gallery Image"> <div class="media-overlay"><i class="fas fa-eye text-white text-3xl"></i></div> </div>
             `).join('');
+            galleryContainer.querySelectorAll('img.blur-up').forEach(img => {
+                if (img.complete) img.classList.add('loaded');
+                else img.addEventListener('load', () => img.classList.add('loaded'));
+            });
 
             initializePageFunctionality();
         });
@@ -641,14 +692,20 @@
                 filtersContainer.addEventListener('click', (e) => {
                     const target = e.target.closest('.service-filter-btn');
                     if (!target) return;
-                    
+
                     filtersContainer.querySelector('.active').classList.remove('active');
                     target.classList.add('active');
 
                     const filter = target.dataset.filter;
 
                     serviceItems.forEach(item => {
-                        item.style.display = (filter === 'all' || item.dataset.category === filter) ? 'flex' : 'none';
+                        const show = (filter === 'all' || item.dataset.category === filter);
+                        item.style.display = show ? 'flex' : 'none';
+                        if (show) {
+                            item.classList.remove('fade-in');
+                            void item.offsetWidth;
+                            item.classList.add('fade-in');
+                        }
                     });
                 });
 
@@ -738,7 +795,7 @@
                 }, frameRate);
             }
 
-            const revealElements = document.querySelectorAll('.reveal');
+            const revealElements = document.querySelectorAll('.reveal, .reveal-left, .reveal-right');
             const statsSection = document.getElementById('stats');
 
             const revealObserver = new IntersectionObserver((entries) => {
@@ -762,6 +819,14 @@
                 statsObserver.observe(statsSection);
             }
         }
+
+        window.addEventListener('load', () => {
+            const preloader = document.getElementById('preloader');
+            if(preloader){
+                preloader.classList.add('fade-out');
+                setTimeout(() => preloader.style.display = 'none', 500);
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Enhance service and stylist cards with hover animations and button press feedback
- Add themed hero overlay, staggered reveals, and gallery/reel overlays
- Introduce blur-up image loading and a logo preloader while reducing stats section spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f7bc38d50832eb6ae7f408088330b