### PR TITLE
feat: restructure hero banner layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,20 +311,18 @@
     </header>
 
     <main class="pt-24">
-        <section id="hero-slider" class="w-full h-[56vh] flex">
-            <div class="w-1/4 bg-brand-light flex flex-col items-center justify-center p-6 text-center">
-                <img id="company-logo" class="mb-4 max-w-full h-auto" alt="Company Logo">
-                <div class="text-sm text-gray-600 space-y-1">
-                    <p><i class="fas fa-map-marker-alt text-brand-accent mr-1"></i><span id="company-address"></span></p>
-                    <p><i class="fas fa-phone text-brand-accent mr-1"></i><span id="company-phone"></span></p>
-                    <p><i class="fas fa-clock text-brand-accent mr-1"></i><span id="company-hours"></span></p>
-                </div>
+        <section id="hero-slider" class="w-full h-screen flex">
+            <div class="w-1/4 bg-brand-light flex items-center justify-center p-6 flex-none">
+                <img id="company-logo" class="max-w-full h-auto" alt="Company Logo">
             </div>
-            <div class="relative w-3/4 h-full overflow-hidden">
+            <div class="relative flex-1 h-full overflow-hidden">
                 <div id="hero-container" class="w-full h-full flex transition-transform duration-500 ease-in-out"></div>
                 <button id="hero-scroll-left" class="absolute top-1/2 -translate-y-1/2 left-4 bg-white/30 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-md hover:bg-white/50 transition z-10"><i class="fas fa-chevron-left"></i></button>
                 <button id="hero-scroll-right" class="absolute top-1/2 -translate-y-1/2 right-4 bg-white/30 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-md hover:bg-white/50 transition z-10"><i class="fas fa-chevron-right"></i></button>
                 <div id="hero-pagination" class="absolute bottom-6 left-1/2 -translate-x-1/2 flex space-x-3 z-10"></div>
+            </div>
+            <div class="w-1/4 bg-brand-light flex items-center justify-center p-6 flex-none">
+                <p class="text-sm text-gray-600"><i class="fas fa-map-marker-alt text-brand-accent mr-1"></i><span id="company-address"></span></p>
             </div>
         </section>
 
@@ -485,8 +483,6 @@
                 preloaderLogo.alt = `${data.businessName} loading`;
             }
             document.getElementById('company-address').textContent = data.contact.location;
-            document.getElementById('company-phone').textContent = data.contact.phone;
-            document.getElementById('company-hours').textContent = data.contact.hours;
 
             const styleTag = document.getElementById('dynamic-styles');
             styleTag.innerHTML = `


### PR DESCRIPTION
## Summary
- make hero slider span full screen
- place logo on left and location on right around scrollable slides

## Testing
- `npm test` (fails: ENOENT could not read package.json)

------
https://chatgpt.com/codex/tasks/task_b_68900cd9623c832e898b6956da7ac328