### PR TITLE
Add new service categories and detail links

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,34 @@
         <i class="fa-solid fa-clinic-medical text-4xl text-[var(--brand-accent)] mb-4"></i>
         <span class="text-lg font-semibold">Clinic</span>
       </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="foodResults">
+        <i class="fa-solid fa-burger text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Food Take Away</span>
+      </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="laundryResults">
+        <i class="fa-solid fa-shirt text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Laundry</span>
+      </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="turfResults">
+        <i class="fa-solid fa-golf-ball-tee text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Turf Club</span>
+      </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="gamezoneResults">
+        <i class="fa-solid fa-gamepad text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Gamezone</span>
+      </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="massageResults">
+        <i class="fa-solid fa-hand-holding-heart text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Massage</span>
+      </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="eventResults">
+        <i class="fa-solid fa-calendar-check text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Event Management</span>
+      </button>
+      <button class="category-card bg-white p-6 rounded-lg shadow-md hover:shadow-xl transition flex flex-col items-center text-center" data-target="petClinicResults">
+        <i class="fa-solid fa-paw text-4xl text-[var(--brand-accent)] mb-4"></i>
+        <span class="text-lg font-semibold">Pet Clinic</span>
+      </button>
     </div>
   </section>
 
@@ -76,7 +104,7 @@
           <div class="p-6">
             <h4 class="text-xl font-semibold mb-2">Glitz 5</h4>
             <p class="text-gray-600 mb-4">Trendy looks and professional care.</p>
-            <a href="#" class="text-[var(--brand-accent)] font-semibold">View details</a>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
           </div>
         </div>
       </div>
@@ -91,7 +119,7 @@
           <div class="p-6">
             <h4 class="text-xl font-semibold mb-2">Relax &amp; Revive</h4>
             <p class="text-gray-600 mb-4">Experience tranquility with our spa treatments.</p>
-            <a href="#" class="text-[var(--brand-accent)] font-semibold">View details</a>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
           </div>
         </div>
       </div>
@@ -106,7 +134,7 @@
           <div class="p-6">
             <h4 class="text-xl font-semibold mb-2">Beauty Hub</h4>
             <p class="text-gray-600 mb-4">Your destination for style and care.</p>
-            <a href="#" class="text-[var(--brand-accent)] font-semibold">View details</a>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
           </div>
         </div>
       </div>
@@ -121,7 +149,112 @@
           <div class="p-6">
             <h4 class="text-xl font-semibold mb-2">Health First</h4>
             <p class="text-gray-600 mb-4">Professional clinic services for your wellness.</p>
-            <a href="#" class="text-[var(--brand-accent)] font-semibold">View details</a>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="foodResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Food take away results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Quick Bites</h4>
+            <p class="text-gray-600 mb-4">Delicious meals ready for pickup.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="laundryResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Laundry results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Sparkle Cleaners</h4>
+            <p class="text-gray-600 mb-4">Professional laundry services for all garments.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="turfResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Turf club results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Green Field Turf</h4>
+            <p class="text-gray-600 mb-4">Premium turf for sports and events.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="gamezoneResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Gamezone results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Arcadia Zone</h4>
+            <p class="text-gray-600 mb-4">Fun games and entertainment for everyone.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="massageResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Massage results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Relaxify Massage</h4>
+            <p class="text-gray-600 mb-4">Rejuvenating massages for body and mind.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="eventResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Event management results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Event Pro</h4>
+            <p class="text-gray-600 mb-4">Expert planning for memorable events.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="petClinicResults" class="hidden py-16 bg-[var(--brand-light)] results-section">
+    <div class="max-w-6xl mx-auto">
+      <h3 class="text-3xl font-bold text-center mb-12">Pet clinic results</h3>
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        <div class="bg-white rounded-lg shadow-md border-t-4 border-[var(--brand-accent)]">
+          <div class="p-6">
+            <h4 class="text-xl font-semibold mb-2">Paw Care</h4>
+            <p class="text-gray-600 mb-4">Comprehensive healthcare for your pets.</p>
+            <a href="businessview.html" class="text-[var(--brand-accent)] font-semibold">View details</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- extend landing page with new categories like food take away, laundry, turf club, gamezone, massage, event management, and pet clinic
- link all business cards' *View details* buttons to the business view page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6892159f6aa4832e990da85587392bd9