### PR TITLE
Add sample businesses and data for all categories

### DIFF
--- a/data/businesses.json
+++ b/data/businesses.json
@@ -16,5 +16,95 @@
     "rating": 4.9,
     "address": "456 Glamour Ave, Sparkle City",
     "phone": "9876543210"
+  },
+  {
+    "id": "relaxspa",
+    "name": "Relax Spa",
+    "category": "spa",
+    "description": "Your place to unwind and rejuvenate.",
+    "rating": 4.7,
+    "address": "1 Spa Street, Relax City",
+    "phone": "1111111111"
+  },
+  {
+    "id": "glowparlour",
+    "name": "Glow Parlour",
+    "category": "parlour",
+    "description": "Beauty treatments for a radiant you.",
+    "rating": 4.6,
+    "address": "22 Shine Ave, Glam Town",
+    "phone": "2222222222"
+  },
+  {
+    "id": "healthclinic",
+    "name": "Health Clinic",
+    "category": "clinic",
+    "description": "Caring professionals for your health.",
+    "rating": 4.8,
+    "address": "33 Wellness Rd, Care City",
+    "phone": "3333333333"
+  },
+  {
+    "id": "quickbites",
+    "name": "Quick Bites",
+    "category": "food",
+    "description": "Fast and tasty takeaway meals.",
+    "rating": 4.3,
+    "address": "44 Snack St, Foodville",
+    "phone": "4444444444"
+  },
+  {
+    "id": "washnfold",
+    "name": "Wash n Fold",
+    "category": "laundry",
+    "description": "Fresh laundry services.",
+    "rating": 4.4,
+    "address": "55 Clean St, Fresh Town",
+    "phone": "5555555555"
+  },
+  {
+    "id": "greensideturf",
+    "name": "Greenside Turf",
+    "category": "turf",
+    "description": "Play on premium turf.",
+    "rating": 4.5,
+    "address": "66 Field Rd, Sport City",
+    "phone": "6666666666"
+  },
+  {
+    "id": "funzone",
+    "name": "Fun Zone",
+    "category": "gamezone",
+    "description": "Arcade games for everyone.",
+    "rating": 4.2,
+    "address": "77 Play Ave, Joy Town",
+    "phone": "7777777777"
+  },
+  {
+    "id": "zenmassage",
+    "name": "Zen Massage",
+    "category": "massage",
+    "description": "Relaxing massage therapies.",
+    "rating": 4.9,
+    "address": "88 Calm St, Peace City",
+    "phone": "8888888888"
+  },
+  {
+    "id": "eventify",
+    "name": "Eventify",
+    "category": "event",
+    "description": "Event planning made easy.",
+    "rating": 4.6,
+    "address": "99 Party Blvd, Festive City",
+    "phone": "9999999999"
+  },
+  {
+    "id": "petcare",
+    "name": "Pet Care Clinic",
+    "category": "petclinic",
+    "description": "Compassionate pet health services.",
+    "rating": 4.8,
+    "address": "11 Paw Rd, Pet Town",
+    "phone": "1010101010"
   }
 ]

--- a/data/eventify.json
+++ b/data/eventify.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Eventify",
+  "logo": "https://placehold.co/200x80?text=Eventify",
+  "rating": 4.6,
+  "contact": { "location": "99 Party Blvd, Festive City", "phone": "9999999999", "hours": "Mon - Fri: 9am - 6pm", "whatsapp": "9999999999" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Eventify", "title": "Make It Memorable", "subtitle": "Event planning made easy" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.6", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Birthday Package", "duration": "Full day", "price": "₹ 15000", "category": "event", "icon": "BP" } ],
+  "reviews": [ { "name": "Anil K.", "rating": 5, "service": "Event Planning", "comment": "Wonderful arrangements!" } ],
+  "stylists": [],
+  "reels": [],
+  "gallery": []
+}

--- a/data/funzone.json
+++ b/data/funzone.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Fun Zone",
+  "logo": "https://placehold.co/200x80?text=Fun+Zone",
+  "rating": 4.2,
+  "contact": { "location": "77 Play Ave, Joy Town", "phone": "7777777777", "hours": "Daily: 10am - 10pm", "whatsapp": "7777777777" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Fun+Zone", "title": "Game On!", "subtitle": "Arcade fun for everyone" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.2", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Arcade Pass", "duration": "60 mins", "price": "₹ 300", "category": "gamezone", "icon": "AP" } ],
+  "reviews": [ { "name": "Kevin L.", "rating": 4, "service": "Arcade", "comment": "Kids loved it." } ],
+  "stylists": [],
+  "reels": [],
+  "gallery": []
+}

--- a/data/glowparlour.json
+++ b/data/glowparlour.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Glow Parlour",
+  "logo": "https://placehold.co/200x80?text=Glow+Parlour",
+  "rating": 4.6,
+  "contact": { "location": "22 Shine Ave, Glam Town", "phone": "2222222222", "hours": "Mon - Sat: 10am - 7pm", "whatsapp": "2222222222" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Glow+Parlour", "title": "Look Your Best", "subtitle": "Make everyday a glam day" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.6", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Facial", "duration": "45 mins", "price": "₹ 1200", "category": "parlour", "icon": "FA" } ],
+  "reviews": [ { "name": "Sara P.", "rating": 5, "service": "Facial", "comment": "Glowing results!" } ],
+  "stylists": [ { "name": "Riya", "title": "Beautician", "image": "https://placehold.co/400x400" } ],
+  "reels": [],
+  "gallery": []
+}

--- a/data/greensideturf.json
+++ b/data/greensideturf.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Greenside Turf",
+  "logo": "https://placehold.co/200x80?text=Greenside+Turf",
+  "rating": 4.5,
+  "contact": { "location": "66 Field Rd, Sport City", "phone": "6666666666", "hours": "Daily: 6am - 10pm", "whatsapp": "6666666666" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Greenside+Turf", "title": "Play on Premium Turf", "subtitle": "Book your slot today" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.5", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Turf Hour", "duration": "60 mins", "price": "₹ 1200", "category": "turf", "icon": "TH" } ],
+  "reviews": [ { "name": "Rahul V.", "rating": 4, "service": "Turf Booking", "comment": "Great surface for football." } ],
+  "stylists": [],
+  "reels": [],
+  "gallery": []
+}

--- a/data/healthclinic.json
+++ b/data/healthclinic.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Health Clinic",
+  "logo": "https://placehold.co/200x80?text=Health+Clinic",
+  "rating": 4.8,
+  "contact": { "location": "33 Wellness Rd, Care City", "phone": "3333333333", "hours": "Mon - Fri: 8am - 6pm", "whatsapp": "3333333333" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Health+Clinic", "title": "Your Health, Our Priority", "subtitle": "Professional care when you need it" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.8", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "General Checkup", "duration": "30 mins", "price": "₹ 500", "category": "clinic", "icon": "GC" } ],
+  "reviews": [ { "name": "Liam K.", "rating": 5, "service": "Checkup", "comment": "Friendly staff and quick service." } ],
+  "stylists": [ { "name": "Dr. Maya", "title": "Physician", "image": "https://placehold.co/400x400" } ],
+  "reels": [],
+  "gallery": []
+}

--- a/data/petcare.json
+++ b/data/petcare.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Pet Care Clinic",
+  "logo": "https://placehold.co/200x80?text=Pet+Care",
+  "rating": 4.8,
+  "contact": { "location": "11 Paw Rd, Pet Town", "phone": "1010101010", "hours": "Mon - Sat: 9am - 8pm", "whatsapp": "1010101010" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Pet+Care", "title": "Care for Your Pets", "subtitle": "Compassionate pet health services" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.8", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Vet Consultation", "duration": "30 mins", "price": "₹ 500", "category": "petclinic", "icon": "VC" } ],
+  "reviews": [ { "name": "Mark D.", "rating": 5, "service": "Consultation", "comment": "Took great care of my dog." } ],
+  "stylists": [ { "name": "Dr. Neha", "title": "Veterinarian", "image": "https://placehold.co/400x400" } ],
+  "reels": [],
+  "gallery": []
+}

--- a/data/quickbites.json
+++ b/data/quickbites.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Quick Bites",
+  "logo": "https://placehold.co/200x80?text=Quick+Bites",
+  "rating": 4.3,
+  "contact": { "location": "44 Snack St, Foodville", "phone": "4444444444", "hours": "Daily: 11am - 11pm", "whatsapp": "4444444444" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Quick+Bites", "title": "Fast & Tasty", "subtitle": "Grab a bite on the go" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.3", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Veg Burger", "duration": "10 mins", "price": "₹ 120", "category": "food", "icon": "VB" } ],
+  "reviews": [ { "name": "Asha M.", "rating": 4, "service": "Burger", "comment": "Tasty and quick." } ],
+  "stylists": [],
+  "reels": [],
+  "gallery": []
+}

--- a/data/relaxspa.json
+++ b/data/relaxspa.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Relax Spa",
+  "logo": "https://placehold.co/200x80?text=Relax+Spa",
+  "rating": 4.7,
+  "contact": { "location": "1 Spa Street, Relax City", "phone": "1111111111", "hours": "Mon - Sun: 9am - 9pm", "whatsapp": "1111111111" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Relax+Spa", "title": "Relax and Unwind", "subtitle": "Experience our top-notch spa treatments" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.7", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Full Body Massage", "duration": "60 mins", "price": "₹ 1500", "category": "spa", "icon": "FB" } ],
+  "reviews": [ { "name": "John D.", "rating": 5, "service": "Massage", "comment": "Very relaxing!" } ],
+  "stylists": [ { "name": "Alice", "title": "Therapist", "image": "https://placehold.co/400x400" } ],
+  "reels": [],
+  "gallery": []
+}

--- a/data/washnfold.json
+++ b/data/washnfold.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Wash n Fold",
+  "logo": "https://placehold.co/200x80?text=Wash+n+Fold",
+  "rating": 4.4,
+  "contact": { "location": "55 Clean St, Fresh Town", "phone": "5555555555", "hours": "Mon - Sat: 8am - 8pm", "whatsapp": "5555555555" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Wash+n+Fold", "title": "Fresh Clothes, Every Time", "subtitle": "Convenient laundry services" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.4", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Regular Wash", "duration": "24 hrs", "price": "₹ 80/kg", "category": "laundry", "icon": "RW" } ],
+  "reviews": [ { "name": "Nina S.", "rating": 5, "service": "Laundry", "comment": "Clothes came back spotless." } ],
+  "stylists": [],
+  "reels": [],
+  "gallery": []
+}

--- a/data/zenmassage.json
+++ b/data/zenmassage.json
@@ -1,0 +1,16 @@
+{
+  "businessName": "Zen Massage",
+  "logo": "https://placehold.co/200x80?text=Zen+Massage",
+  "rating": 4.9,
+  "contact": { "location": "88 Calm St, Peace City", "phone": "8888888888", "hours": "Daily: 9am - 9pm", "whatsapp": "8888888888" },
+  "theme": { "charcoal": "#36322F", "accent": "#C08261", "light": "#F5EFE6" },
+  "heroSlides": [
+    { "bgImage": "https://placehold.co/1920x1080/C08261/FFFFFF?text=Zen+Massage", "title": "Find Your Zen", "subtitle": "Relaxing massage therapies" }
+  ],
+  "stats": [ { "icon": "fas fa-star", "value": "4.9", "decimal": 1, "label": "Rating" } ],
+  "services": [ { "name": "Deep Tissue Massage", "duration": "60 mins", "price": "₹ 1800", "category": "massage", "icon": "DT" } ],
+  "reviews": [ { "name": "Priya S.", "rating": 5, "service": "Massage", "comment": "Best massage experience." } ],
+  "stylists": [ { "name": "Sunita", "title": "Masseur", "image": "https://placehold.co/400x400" } ],
+  "reels": [],
+  "gallery": []
+}


### PR DESCRIPTION
## Summary
- add placeholder business entries for all categories in `businesses.json`
- provide individual JSON data files so each business view can load its details

## Testing
- `python -m json.tool data/businesses.json`
- `for f in data/*.json; do python -m json.tool "$f" >/dev/null && echo "validated $f"; done`


------
https://chatgpt.com/codex/tasks/task_b_6892df179bfc832e88321f16c7fc92ef