### PR TITLE
feat: modernize stats section

### DIFF
--- a/businessview.html
+++ b/businessview.html
@@ -76,10 +76,22 @@
             display: block;
         }
 
-        /* Stat Card Styles */
+        /* Stat Section Styles */
         .stat-card {
-            @apply bg-white p-6 rounded-lg shadow-lg text-center transform transition-transform duration-300 hover:-translate-y-2 border-2;
-            border-color: var(--brand-accent);
+            @apply bg-white/40 backdrop-blur-md p-8 rounded-xl border border-white/40 shadow-lg text-center transform transition-transform duration-300 hover:-translate-y-1 hover:shadow-2xl;
+        }
+        .stat-card .icon-wrapper {
+            @apply w-16 h-16 mx-auto mb-4 flex items-center justify-center rounded-full text-3xl text-white shadow-md;
+            background: linear-gradient(135deg, var(--brand-accent), var(--brand-charcoal));
+        }
+        .stat-number {
+            @apply text-4xl font-extrabold mb-1;
+            background: linear-gradient(135deg, var(--brand-charcoal), var(--brand-accent));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .stat-label {
+            @apply uppercase tracking-wider text-xs text-gray-600;
         }
 
         /* Review Card Styles */
@@ -236,9 +248,13 @@
             </div>
         </section>
 
-        <section id="stats" class="bg-brand-light parallax" style="padding-top:1.35rem;padding-bottom:1.35rem;">
+        <section id="stats" class="py-24 bg-brand-light parallax">
             <div class="container mx-auto px-6">
-                <div id="stats-grid" class="grid grid-cols-1 md:grid-cols-4 gap-8"></div>
+                <div class="text-center mb-12 reveal">
+                    <h3 class="text-4xl font-bold mb-2">Our Impact</h3>
+                    <p class="text-lg text-gray-600">Numbers that drive our business forward</p>
+                </div>
+                <div id="stats-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8"></div>
             </div>
         </section>
 
@@ -503,13 +519,11 @@
             const statsGrid = document.getElementById('stats-grid');
             statsGrid.innerHTML = data.stats.map((stat, index) => `
                 <div class="stat-card reveal" style="transition-delay: ${index * 150}ms;">
-                    <div class="text-5xl font-bold text-brand-accent mb-2">
+                    <div class="icon-wrapper">
                         <i class="${stat.icon}"></i>
                     </div>
-                    <div class="text-3xl font-bold text-brand-charcoal">
-                        <span class="stat-number" data-count="${stat.value}" data-decimal="${stat.decimal || 0}">0</span>
-                    </div>
-                    <p class="text-gray-500 mt-1">${stat.label}</p>
+                    <div class="stat-number" data-count="${stat.value}" data-decimal="${stat.decimal || 0}">0</div>
+                    <p class="stat-label">${stat.label}</p>
                 </div>
             `).join('');
 


### PR DESCRIPTION
## Summary
- modern stats cards with gradient icon wrapper and glassy backdrop
- add "Our Impact" heading and responsive grid for stat section
- update JS to output new stat card markup

## Testing
- `tidy -q -e businessview.html` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_689347947d9c832e991c7efafa917d3e