### PR TITLE
Redesign stats section with modern card layout

### DIFF
--- a/businessview.html
+++ b/businessview.html
@@ -78,8 +78,11 @@
 
         /* Stat Card Styles */
         .stat-card {
-            @apply bg-white p-6 rounded-lg shadow-lg text-center transform transition-transform duration-300 hover:-translate-y-2 border-2;
-            border-color: var(--brand-accent);
+            @apply bg-white/80 backdrop-blur rounded-xl p-6 text-center shadow-lg transform transition-transform duration-300 hover:-translate-y-2 hover:shadow-2xl;
+        }
+        .stat-icon {
+            @apply w-16 h-16 mx-auto mb-4 rounded-full flex items-center justify-center text-3xl text-white shadow-lg;
+            background: linear-gradient(135deg, var(--brand-accent), var(--brand-charcoal));
         }
 
         /* Review Card Styles */
@@ -236,9 +239,13 @@
             </div>
         </section>
 
-        <section id="stats" class="bg-brand-light parallax" style="padding-top:1.35rem;padding-bottom:1.35rem;">
+        <section id="stats" class="bg-brand-light parallax py-24">
             <div class="container mx-auto px-6">
-                <div id="stats-grid" class="grid grid-cols-1 md:grid-cols-4 gap-8"></div>
+                <div class="text-center mb-12">
+                    <h3 class="text-4xl font-bold mb-3">Our Achievements</h3>
+                    <p class="text-gray-600">Numbers that speak for themselves</p>
+                </div>
+                <div id="stats-grid" class="grid grid-cols-2 md:grid-cols-4 gap-8"></div>
             </div>
         </section>
 
@@ -503,13 +510,13 @@
             const statsGrid = document.getElementById('stats-grid');
             statsGrid.innerHTML = data.stats.map((stat, index) => `
                 <div class="stat-card reveal" style="transition-delay: ${index * 150}ms;">
-                    <div class="text-5xl font-bold text-brand-accent mb-2">
+                    <div class="stat-icon">
                         <i class="${stat.icon}"></i>
                     </div>
-                    <div class="text-3xl font-bold text-brand-charcoal">
+                    <div class="text-4xl font-extrabold text-brand-charcoal">
                         <span class="stat-number" data-count="${stat.value}" data-decimal="${stat.decimal || 0}">0</span>
                     </div>
-                    <p class="text-gray-500 mt-1">${stat.label}</p>
+                    <p class="mt-2 text-sm uppercase tracking-wide text-gray-600">${stat.label}</p>
                 </div>
             `).join('');
 


### PR DESCRIPTION
## Summary
- refresh stats section with a new "Our Achievements" header
- add gradient icon badges and glass-style stat cards
- render stats with updated markup for business-friendly style

## Testing
- `npx htmlhint businessview.html` *(fails: 403 Forbidden)*
- `npx prettier --check businessview.html`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689350654f60832e84755602ad354837