### PR TITLE
Refresh stats section with modern card design

### DIFF
--- a/businessview.html
+++ b/businessview.html
@@ -78,8 +78,15 @@
 
         /* Stat Card Styles */
         .stat-card {
-            @apply bg-white p-6 rounded-lg shadow-lg text-center transform transition-transform duration-300 hover:-translate-y-2 border-2;
+            @apply bg-white/60 backdrop-blur p-6 rounded-xl shadow-md text-center border-2 transform transition-all duration-300 hover:-translate-y-1 hover:shadow-xl;
             border-color: var(--brand-accent);
+        }
+        .stat-icon {
+            @apply w-16 h-16 flex items-center justify-center rounded-full mb-4 text-2xl text-white;
+            background-color: var(--brand-accent);
+        }
+        .stat-number {
+            @apply text-4xl font-bold text-brand-charcoal;
         }
 
         /* Review Card Styles */
@@ -236,9 +243,10 @@
             </div>
         </section>
 
-        <section id="stats" class="bg-brand-light parallax" style="padding-top:1.35rem;padding-bottom:1.35rem;">
+        <section id="stats" class="py-20 bg-gradient-to-r from-[var(--brand-light)] to-white">
             <div class="container mx-auto px-6">
-                <div id="stats-grid" class="grid grid-cols-1 md:grid-cols-4 gap-8"></div>
+                <h3 class="text-4xl font-bold text-center mb-12">Our Impact in Numbers</h3>
+                <div id="stats-grid" class="grid grid-cols-2 md:grid-cols-4 gap-8"></div>
             </div>
         </section>
 
@@ -502,14 +510,10 @@
 
             const statsGrid = document.getElementById('stats-grid');
             statsGrid.innerHTML = data.stats.map((stat, index) => `
-                <div class="stat-card reveal" style="transition-delay: ${index * 150}ms;">
-                    <div class="text-5xl font-bold text-brand-accent mb-2">
-                        <i class="${stat.icon}"></i>
-                    </div>
-                    <div class="text-3xl font-bold text-brand-charcoal">
-                        <span class="stat-number" data-count="${stat.value}" data-decimal="${stat.decimal || 0}">0</span>
-                    </div>
-                    <p class="text-gray-500 mt-1">${stat.label}</p>
+                <div class="stat-card reveal flex flex-col items-center" style="transition-delay: ${index * 150}ms;">
+                    <div class="stat-icon"><i class="${stat.icon}"></i></div>
+                    <span class="stat-number" data-count="${stat.value}" data-decimal="${stat.decimal || 0}">0</span>
+                    <p class="mt-2 text-gray-600">${stat.label}</p>
                 </div>
             `).join('');
 


### PR DESCRIPTION
## Summary
- Reworked stats section with gradient background and heading
- Added glassmorphic stat cards featuring circular icons and large counters

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689350654f60832e84755602ad354837